### PR TITLE
Addressing bug in params preventing 0 values from being assigned to E_g and E_e

### DIFF
--- a/main.C
+++ b/main.C
@@ -8,7 +8,7 @@
 //* Copyright 2024, North Carolina State University
 //* ALL RIGHTS RESERVED
 //*
-
+  
 #include <stdlib.h>
 #include "prism/prism.h"
 #include "fmt/core.h"

--- a/src/Reaction.C
+++ b/src/Reaction.C
@@ -69,17 +69,17 @@ Reaction::Reaction(const YAML::Node & rxn_input,
     _tabulated_data.resize(0);
     if (_params[0] <= 0.0)
       throw InvalidReaction(_expression,
-                            "The first value of '" + PARAM_KEY + "'cannot be zero or negative");
+                            "The first value of '" + PARAM_KEY + "' cannot be zero or negative");
 
-    if (_params.size() > 2 && _params[2] <= 0.0)
+    if (_params.size() > 2 && _params[2] < 0.0)
       throw InvalidReaction(_expression,
                             "The theshold energy E_e (index 2) in '" + PARAM_KEY +
-                                "'cannot be zero or negative");
+                                "' cannot be negative");
 
-    if (_params.size() == 5 && _params[4] <= 0.0)
+    if (_params.size() == 5 && _params[4] < 0.0)
       throw InvalidReaction(_expression,
                             "The theshold energy E_g (index 4) in '" + PARAM_KEY +
-                                "'cannot be zero or negative");
+                                "' cannot be negative");
 
     switch (_params.size())
     {

--- a/test/tests/ReactionTest.C
+++ b/test/tests/ReactionTest.C
@@ -359,3 +359,23 @@ TEST(Reaction, FullArrhenius)
   EXPECT_REL_TOL(r.sampleData(5.0, 3.0), 4.37108820797);
   EXPECT_REL_TOL(r.sampleData(7.0, 5.0), 33.2533008159);
 }
+
+TEST(Reaction, ArrheniusZeroes)
+{
+  YAML::Node rxn_input;
+  rxn_input[REACTION_KEY] = "Ar + e -> Ar + e";
+  rxn_input[PARAM_KEY] = YAML::Load("[2, 0, 0, 0, 0]");
+
+  Reaction r = Reaction(rxn_input, 0, "", "", false, true, "\t");
+
+  EXPECT_NO_THROW(Reaction(rxn_input, 0, "", "", false, true, "\t"));
+}
+
+TEST(Reaction, ArrheniusZeroes2)
+{
+  YAML::Node rxn_input;
+  rxn_input[REACTION_KEY] = "Ar + e -> Ar + e";
+  rxn_input[PARAM_KEY] = YAML::Load("[0, 0.25, 4.0, 0.75, 10]");
+
+  EXPECT_THROW(Reaction(rxn_input, 0, "", "", false, true, "\t"), InvalidReaction);
+}


### PR DESCRIPTION
Ignore first two commits, was testing something.
Changed comparison function in Reaction.C to allow 0 in params E_g and E_g as well as changing the associated error message.
Added 2 reaction tests to ReactionTest.C to confirm that 0 values in param indices 2 and 4 would not prevent reaction evaluation, as well as checking that a zero in index 0 would throw an error.