### PR TITLE
Updating Documentation, addressing issues #10 and #18

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/gsgall/rxn-cpp/issues).
+      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/NCSU-ComPS-Group/prism/issues).
 - type: textarea
   attributes:
     label: Bug Description
@@ -19,7 +19,7 @@ body:
     label: Steps to Reproduce
     description: |
       In order to make it easier for us to address your issue we request that you write a test to be added to the test suite that covers your case.
-      If you need help writing a case please first look at the examples in the `test/tests` directory and if you need further assistance please reach out on the discussions forum (https://github.com/gsgall/rxn-cpp/discussions).
+      If you need help writing a case please first look at the examples in the `test/tests` directory and if you need further assistance please reach out on the discussions forum (https://github.com/NCSU-ComPS-Group/prism/discussions).
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions
-    url: https://github.com/gsgall/rxn-cpp/discussions
-    about: Ask general questions about rxn-cpp and discuss with other community members.
+    url: https://github.com/NCSU-ComPS-Group/prism/discussions
+    about: Ask general questions about PRISM and discuss with other community members.

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -215,3 +215,19 @@ You do not have to expliticty provide all of the parameters for a reaction which
 ## Example input files
 
 For more complete examples of input files please checkout the [inputs](https://github.com/NCSU-ComPS-Group/prism/tree/devel/test/inputs) that are used for testing PRISM.
+
+
+## Running Input Files
+
+Input files are run with the ./main.C command, using the following format: 
+
+./main.C <input-file> -s <summary-file> -l <latex-file>
+
+| Parameter | Description | Required? |
+| - | - | - |
+| <input-file> | The path to the yaml file containing the reaction network you want to parse | yes |
+| -s <summary-file> | If this parameter is provided a species summary file will be written to <summary-file> | no |
+| -l <latex-file> | If this parameter is provided a latex file containing the reaction network will be written to <latex-file> | no |
+
+!alert note
+If no arguments are provided the example file "example/simple_argon_rate.yaml" will run, additionally creating the two files "example/table.tex" and "example/summary.yaml"

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -219,15 +219,17 @@ For more complete examples of input files please checkout the [inputs](https://g
 
 ## Running Input Files
 
-Input files are run with the ./main.C command, using the following format: 
+Input files are run with the `./main.C` command, using the following format: 
 
-  > ./main.C \<input-file\> -s \<summary-file\> -l \<latex-file\>
+```
+./main.C <input-file> -s <summary-file> -l <latex-file>
+```
 
 | Parameter | Description | Required? |
 | - | - | - |
 | \<input-file\> | The path to the yaml file containing the reaction network you want to parse | yes |
-| -s \<summary-file\> | If this parameter is provided a species summary file will be written to \<summary-file\> | no |
-| -l \<latex-file\> | If this parameter is provided a latex file containing the reaction network will be written to \<latex-file\> | no |
+| -s \<summary-file\> | If this parameter is provided a species summary file will be written to `<summary-file>` | no |
+| -l \<latex-file\> | If this parameter is provided a latex file containing the reaction network will be written to `<latex-file>` | no |
 
 !alert note
 If no arguments are provided the example file "example/simple_argon_rate.yaml" will run, additionally creating the two files "example/table.tex" and "example/summary.yaml"

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -227,9 +227,9 @@ Input files are run with the `./main.C` command, using the following format:
 
 | Parameter | Description | Required? |
 | - | - | - |
-| \<input-file\> | The path to the yaml file containing the reaction network you want to parse | yes |
-| -s \<summary-file\> | If this parameter is provided a species summary file will be written to `<summary-file>` | no |
-| -l \<latex-file\> | If this parameter is provided a latex file containing the reaction network will be written to `<latex-file>` | no |
+| <input-file> | The path to the yaml file containing the reaction network you want to parse | yes |
+| -s <summary-file> | If this parameter is provided a species summary file will be written to `<summary-file>` | no |
+| -l <latex-file> | If this parameter is provided a latex file containing the reaction network will be written to `<latex-file>` | no |
 
 !alert note
 If no arguments are provided the example file "example/simple_argon_rate.yaml" will run. This will also output two files "example/table.tex" and "example/summary.yaml"

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -17,7 +17,7 @@ The PRISM project utilizes the yaml file format to store reaction networks. The 
 In the PRISM format every reaction is required to have at least one cite key associated with it. This blocks allows you to specify a bibliography file in which these cite keys exist.
 
 !alert note
-The bibliograpy file must be in the [BibTex](https://www.bibtex.com) format in order to better support documenting a reaction mechanism in $\LaTeX$.
+The bibliography file must be in the [BibTex](https://www.bibtex.com) format in order to better support documenting a reaction mechanism in $\LaTeX$.
 
 This block only requires a single string which is the path from the location of the executable which is reading the input file to the bibliography file
 
@@ -104,7 +104,7 @@ lumped-species:
     actual: [N2(rotation), N2(vibration)]
 ```
 
-With the lumped species block above the states `N2(rotational)` and `N2(vibrational)` will be substituded with `N2*` when parsing the reactions which contain those excited states. You can also define an arbitrary number of lumped states.
+With the lumped species block above the states `N2(rotational)` and `N2(vibrational)` will be substituted with `N2*` when parsing the reactions which contain those excited states. You can also define an arbitrary number of lumped states.
 
 ```yaml
 lumped-species:
@@ -154,12 +154,12 @@ Inputs can include both the `rate-based` block, and the `xsec-based` block. Eith
 
 | Parameter | Description | Data Type | Required? | Default Value |
 | - | - | - | - | - |
-| reaction | The symbolic expression of the reaction see |  string | always | N/A |
+| reaction | The symbolic expression of the reaction |  string | always | N/A |
 | delta-eps-e | The change in energy of electrons | float | no | 0.00 |
 | delta-eps-g | The change in energy of the background gas | float | no | 0.00 |
 | file | The file where the tabulated data is stored | string | yes, if params is not provided | "" |
 | params | The parameters required for evaluation of the analytic expression | A float or a list of floats | yes, if file is not provided | [] |
-| reference | The cite keys for recources where the reaction came from | A string or a list of strings | always | N/A |
+| reference | The cite keys for resources where the reaction came from | A string or a list of strings | always | N/A |
 | notes | Any additional helpful notes you may want to add | A string or a list of strings | never | [] |
 
 
@@ -209,10 +209,10 @@ When using the provided sampling functions it is expected that the electron temp
 ```
 
 !alert note
-You do not have to expliticty provide all of the parameters for a reaction which has data in an Arrhenius form. Any parameters which are not provided are assumed to be zero.
+You do not have to explicitly provide all of the parameters for a reaction which has data in an Arrhenius form. Any parameters which are not provided are assumed to be zero.
 
 
-## Example input files
+## Example Input Files
 
 For more complete examples of input files please checkout the [inputs](https://github.com/NCSU-ComPS-Group/prism/tree/devel/test/inputs) that are used for testing PRISM.
 

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -232,4 +232,4 @@ Input files are run with the `./main.C` command, using the following format:
 | -l \<latex-file\> | If this parameter is provided a latex file containing the reaction network will be written to `<latex-file>` | no |
 
 !alert note
-If no arguments are provided the example file "example/simple_argon_rate.yaml" will run, additionally creating the two files "example/table.tex" and "example/summary.yaml"
+If no arguments are provided the example file "example/simple_argon_rate.yaml" will run. This will also output two files "example/table.tex" and "example/summary.yaml"

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -221,7 +221,7 @@ For more complete examples of input files please checkout the [inputs](https://g
 
 Input files are run with the ./main.C command, using the following format: 
 
-./main.C \<input-file\> -s \<summary-file\> -l \<latex-file\>
+  > ./main.C \<input-file\> -s \<summary-file\> -l \<latex-file\>
 
 | Parameter | Description | Required? |
 | - | - | - |

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -221,13 +221,13 @@ For more complete examples of input files please checkout the [inputs](https://g
 
 Input files are run with the ./main.C command, using the following format: 
 
-./main.C <input-file> -s <summary-file> -l <latex-file>
+./main.C \<input-file\> -s \<summary-file\> -l \<latex-file\>
 
 | Parameter | Description | Required? |
 | - | - | - |
-| <input-file> | The path to the yaml file containing the reaction network you want to parse | yes |
-| -s <summary-file> | If this parameter is provided a species summary file will be written to <summary-file> | no |
-| -l <latex-file> | If this parameter is provided a latex file containing the reaction network will be written to <latex-file> | no |
+| \<input-file\> | The path to the yaml file containing the reaction network you want to parse | yes |
+| -s \<summary-file\> | If this parameter is provided a species summary file will be written to \<summary-file\> | no |
+| -l \<latex-file\> | If this parameter is provided a latex file containing the reaction network will be written to \<latex-file\> | no |
 
 !alert note
 If no arguments are provided the example file "example/simple_argon_rate.yaml" will run, additionally creating the two files "example/table.tex" and "example/summary.yaml"


### PR DESCRIPTION
Replacing the old project name "rxn-cpp" with "PRISM" in documentation, and updating related links on the website. 
Adding to the PRISM website information about new main.C features following #15.
Fixing typos and grammatical issues in website documentation.