### PR TITLE
Allowing negative input values for E_g and E_e parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 WARNING_FLAGS = -Wall -Wextra -Wpedantic -Werror
-CXXFLAGS = -std=c++17 -O3 $(WARNING_FLAGS) -g
+CXXFLAGS = -std=c++17 $(WARNING_FLAGS) -g
 # Source file and executable name
 SRC = main.C
 EXE = main

--- a/Makefile-as-dll
+++ b/Makefile-as-dll
@@ -1,6 +1,6 @@
 TESTING_FLAG = -DTESTING
 WARNING_FLAGS = -Wall -Wextra -Wpedantic -Werror
-CXXFLAGS = -std=c++17 $(WARNING_FLAGS) -O3 -g
+CXXFLAGS = -std=c++17 $(WARNING_FLAGS) -O2
 
 PROJECT = prism
 

--- a/conda/prism-dev/conda_build_config.yaml
+++ b/conda/prism-dev/conda_build_config.yaml
@@ -46,8 +46,8 @@ prism_llvm_tools:                                           # [osx]
 
 prism_libclang:
   - libclang13 20.1.2 default_h9c6a7e4_0                    # [linux]
-  - libclang-cpp18.1 18.1.8 default_h3571c67_9              # [not arm64 and osx]
-  - libclang-cpp18.1 18.1.8 default_hf90f093_9              # [arm64]
+  - libclang-cpp18.1 18.1.8 default_h3571c67_9              # [osx-64]
+  - libclang-cpp18.1 18.1.8 default_hf90f093_9              # [osx-arm64]
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/prism-dev/conda_build_config.yaml
+++ b/conda/prism-dev/conda_build_config.yaml
@@ -47,7 +47,7 @@ prism_llvm_tools:                                           # [osx]
 prism_libclang:
   - libclang13 20.1.2 default_h9c6a7e4_0                    # [linux]
   - libclang-cpp18.1 18.1.8 default_h3571c67_9              # [osx-64]
-  - libclang-cpp18.1 18.1.8 default_hf90f093_9              # [osx-arm64]
+  - libclang-cpp18.1 18.1.8 default_h649e436_14             # [osx-arm64]
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/src/Reaction.C
+++ b/src/Reaction.C
@@ -71,16 +71,6 @@ Reaction::Reaction(const YAML::Node & rxn_input,
       throw InvalidReaction(_expression,
                             "The first value of '" + PARAM_KEY + "' cannot be zero or negative");
 
-    if (_params.size() > 2 && _params[2] < 0.0)
-      throw InvalidReaction(_expression,
-                            "The theshold energy E_e (index 2) in '" + PARAM_KEY +
-                                "' cannot be negative");
-
-    if (_params.size() == 5 && _params[4] < 0.0)
-      throw InvalidReaction(_expression,
-                            "The theshold energy E_g (index 4) in '" + PARAM_KEY +
-                                "' cannot be negative");
-
     switch (_params.size())
     {
       case 1:
@@ -681,10 +671,11 @@ const string
 Reaction::getReferencesAsString() const
 {
   string temp_refs = "\\cite{";
-  for (size_t i = 0; i < _references.size(); i++) {
+  for (size_t i = 0; i < _references.size(); i++)
+  {
     temp_refs += _references[i];
-	if (i != _references.size() - 1)
-		temp_refs += ", ";
+    if (i != _references.size() - 1)
+      temp_refs += ", ";
   }
   temp_refs += "}";
   return temp_refs;

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@ TESTING_FLAG = -DTESTING
 GCOV_FLAGS = -fprofile-arcs -ftest-coverage
 # flags for memory leakage testing
 ASAN_FLAGS = -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope -fsanitize=undefined
-CXXFLAGS = -std=c++17 -Wall -Wextra -Wpedantic -Werror $(GCOV_FLAGS) $(ASAN_FLAGS) $(TESTING_FLAG)
+CXXFLAGS = -std=c++17 -g -Wall -Wextra -Wpedantic -Werror $(GCOV_FLAGS) $(ASAN_FLAGS) $(TESTING_FLAG)
 PROJECT_NAME = prism
 PROJECT_SRC_DIR = ../src
 PROJECT_INCLUDE_DIR = ../include/$(PROJECT_NAME)
@@ -58,8 +58,9 @@ $(TEST_BUILD_DIR)/%.o: $(TEST_SRC_DIR)/%.C
 	@echo "Successfully Built $<"
 
 $(TEST_EXECUTABLE): $(TEST_OBJECTS) $(PROJECT_OBJECTS) $(HELPER_OBJECTS)
+	@rm -rf build/*.g*
 	@mkdir -p outputs
-	@$(CXX) $(CXXFLAGS) -B$(CONDA_PREFIX)/bin -I$(PROJECT_INCLUDE) -I$(HELPER_INCLUDE) -I$(CONDA_INCLUDE_DIR) -L$(CONDA_LIB_DIR) -lgtest -lgtest_main -lyaml-cpp -lfmt -o $@ $^ -Wl,-rpath,$(CONDA_PREFIX)/lib 
+	@$(CXX) $(CXXFLAGS) -B$(CONDA_PREFIX)/bin -I$(PROJECT_INCLUDE) -I$(HELPER_INCLUDE) -I$(CONDA_INCLUDE_DIR) -L$(CONDA_LIB_DIR) -lgtest -lgtest_main -lyaml-cpp -lfmt -o $@ $^ -Wl,-rpath,$(CONDA_PREFIX)/lib
 .PHONY: all clean coverage clean-coverage
 
 

--- a/test/tests/ReactionTest.C
+++ b/test/tests/ReactionTest.C
@@ -382,8 +382,6 @@ TEST(Reaction, ArrheniusZeroes)
   rxn_input[REACTION_KEY] = "Ar + e -> Ar + e";
   rxn_input[PARAM_KEY] = YAML::Load("[2, 0, 0, 0, 0]");
 
-  Reaction r = Reaction(rxn_input, 0, "", "", false, true, "\t");
-
   EXPECT_NO_THROW(Reaction(rxn_input, 0, "", "", false, true, "\t"));
 }
 
@@ -394,4 +392,13 @@ TEST(Reaction, ArrheniusZeroes2)
   rxn_input[PARAM_KEY] = YAML::Load("[0, 0.25, 4.0, 0.75, 10]");
 
   EXPECT_THROW(Reaction(rxn_input, 0, "", "", false, true, "\t"), InvalidReaction);
+}
+
+TEST(Reaction, ArrheniusNegativeValues)
+{
+  YAML::Node rxn_input;
+  rxn_input[REACTION_KEY] = "Ar + e -> Ar + e";
+  rxn_input[PARAM_KEY] = YAML::Load("[2, -1, -1, -1, -1]");
+
+  EXPECT_NO_THROW(Reaction(rxn_input, 0, "", "", false, true, "\t"));
 }


### PR DESCRIPTION
- This addresses issue #22.
- Small Makefile change also clears some of the coverage reports when building so there are no longer large coverage report messages when rebuilding without first cleaning.
- The debug flag was also added to the testing Makefile to make it possible to use a debugger with those cases.
- Also cleaning up some flags that didn't make sense in the main Makefile so that we are not building with debug information and optimizations and that the dlls are not built with debug information either.