### PR TITLE
Enabling elastic for cross section reactions and updating documentation

### DIFF
--- a/doc/content/getting_started/contributing.md
+++ b/doc/content/getting_started/contributing.md
@@ -6,16 +6,16 @@ For the most part PRISM follows the MOOSE code standards for all development. Fo
 
 # Creating a new environment
 
-If you are interested in contributing you will need to download the [prism-dev](https://anaconda.org/gsgall/prism-dev) conda package to facilitate development. This package installs out dependencies and helps set environment variables needed for compilation. To create a new development environment please use the following commands
+If you are interested in contributing you will need to install the prism-dev conda package to facilitate development. This package installs our dependencies. To create a new development environment please use the following commands
 
 ```bash
-  conda create -n prism-dev
-```
-
-```bash
-  conda activate prism-dev
-  conda config --add channels gsgall
-  conda install prism-dev
+cd ~/projects/prism
+conda install -y conda-build
+mkdir -p build
+conda build conda/prism-dev --output-folder build
+conda create -y -n prism-dev
+conda activate prism-dev
+conda install -y prism-dev -c ./build
 ```
 
 ## Creating and Referencing Issues
@@ -123,12 +123,14 @@ unrelated changes all at once.
 !alert note
 Since we rely on [MooseDocs](https://mooseframework.inl.gov/python/MooseDocs/) for our documentation you will need to run these commands in the moose environment. Instructions on this can be found [here](https://mooseframework.inl.gov/getting_started/installation/conda.html)
 
-   ```
+    ```
+    cd ~/prjects/prism
+    git submodule update --init moose
     cd ~/projects/prism/doc/moose/test
     make hit
     cd ../../
     MOOSE_DIR=./moose ROOT_DIR=./ ./moosedocs.py build --num-threads 4 --serve
-   ```
+    ```
 
 1. Type `git status` to see the status of your branch. That should show you the changed files and
    give you some commands to stage them.

--- a/doc/content/getting_started/input_syntax.md
+++ b/doc/content/getting_started/input_syntax.md
@@ -157,6 +157,7 @@ Inputs can include both the `rate-based` block, and the `xsec-based` block. Eith
 | reaction | The symbolic expression of the reaction |  string | always | N/A |
 | delta-eps-e | The change in energy of electrons | double | no | 0.00 |
 | delta-eps-g | The change in energy of the background gas | double | no | 0.00 |
+| elastic | Whether or not the reaction is an elastic collision | bool | no | false |
 | file | The file where the tabulated data is stored | string | yes, if params is not provided | "" |
 | params | The parameters required for evaluation of the analytic expression | A double or a list of doubles | yes, if file is not provided | [] |
 | reference | The cite keys for resources where the reaction came from | A string or a list of strings | always | N/A |
@@ -212,6 +213,9 @@ When using the provided sampling functions it is expected that the electron temp
 You do not have to explicitly provide all of the parameters for a reaction which has data in an Arrhenius form. Any parameters which are not provided are assumed to be zero.
 
 
+!alert note
+If the `elastic` keyword is provided then you may not provide values for `delta-eps-e` or `delta-eps-g`.
+
 ## Example Input Files
 
 For more complete examples of input files please checkout the [inputs](https://github.com/NCSU-ComPS-Group/prism/tree/devel/test/inputs) that are used for testing PRISM.
@@ -219,7 +223,7 @@ For more complete examples of input files please checkout the [inputs](https://g
 
 ## Running Input Files
 
-Input files are run with the `./main.C` command, using the following format: 
+Input files are run with the `./main.C` command, using the following format:
 
 ```
 ./main.C <input-file> -s <summary-file> -l <latex-file>

--- a/example/simple_argon_rate.yaml
+++ b/example/simple_argon_rate.yaml
@@ -11,6 +11,13 @@ lumped-species:
   - lumped: Ar*
     actual: [Ar(a), Ar(b)]
 
+xsec-based:
+
+  - reaction: Ar + e -> Ar + e
+    elastic: true
+    file: ar_elastic.txt
+    references: lymberopoulos1993fluid
+
 rate-based:
 
   - reaction: Ar + e -> Ar(a) + e

--- a/example/summary.yaml
+++ b/example/summary.yaml
@@ -78,12 +78,13 @@ reaction-summary:
       sinks:
         - count: 0
 
-    - xsec-based: 0
+    - xsec-based: 1
       sources:
         - count: 0
 
       balanced:
-        - count: 0
+        - count: 1
+        - Ar + e -> Ar + e
 
       sinks:
         - count: 0
@@ -176,12 +177,13 @@ reaction-summary:
         - Ar + e -> Ar+ + 2e
         - Ar(a) + 2Ar -> Ar2 + Ar
 
-    - xsec-based: 0
+    - xsec-based: 1
       sources:
         - count: 0
 
       balanced:
-        - count: 0
+        - count: 1
+        - Ar + e -> Ar + e
 
       sinks:
         - count: 0

--- a/example/table.tex
+++ b/example/table.tex
@@ -51,7 +51,7 @@
 \end{table}
 
 \newpage
-\section{Rate Reactions}
+\section{Cross Section Reactions}
 \begin{table}[H]
   \centering
   \resizebox{\columnwidth}{!}{
@@ -64,11 +64,11 @@
   }
 \end{table}
 
-\footnotemark[1]{Species \lq Ar$\left(\beta\right)$\rq{}  has been lumped into \lq Ar*\rq}\\ 
-\footnotemark[2]{Species \lq Ar$\left(\alpha\right)$\rq{}  has been lumped into \lq Ar*\rq}\\ 
-\footnotemark[3]{This is a test}\\ 
-\footnotemark[4]{this one}\\ 
-\footnotemark[5]{has 2 notes}\\ 
+\footnotemark[1]{Species \lq Ar$\left(\beta\right)$\rq{}  has been lumped into \lq Ar*\rq}\\
+\footnotemark[2]{Species \lq Ar$\left(\alpha\right)$\rq{}  has been lumped into \lq Ar*\rq}\\
+\footnotemark[3]{This is a test}\\
+\footnotemark[4]{this one}\\
+\footnotemark[5]{has 2 notes}\\
 \newpage
 \printbibliography
 

--- a/example/table.tex
+++ b/example/table.tex
@@ -50,6 +50,20 @@
   }
 \end{table}
 
+\newpage
+\section{Rate Reactions}
+\begin{table}[H]
+  \centering
+  \resizebox{\columnwidth}{!}{
+    \begin{tabu}{clcccccccc}
+      No. & Reaction & $A$ & $n_e$ & $E_e$ & $n_g$ & $E_g$ & $\Delta \varepsilon_e$ & $\Delta \varepsilon_g$ & Ref.\\
+      \hline
+      \hline
+      10 & Ar + e $\rightarrow$ Ar + e &  & & EEDF & & & 0.00 & 0.00 & \cite{lymberopoulos1993fluid} \\
+    \end{tabu}
+  }
+\end{table}
+
 \footnotemark[1]{Species \lq Ar$\left(\beta\right)$\rq{}  has been lumped into \lq Ar*\rq}\\ 
 \footnotemark[2]{Species \lq Ar$\left(\alpha\right)$\rq{}  has been lumped into \lq Ar*\rq}\\ 
 \footnotemark[3]{This is a test}\\ 

--- a/src/NetworkParser.C
+++ b/src/NetworkParser.C
@@ -103,10 +103,6 @@ NetworkParser::parseReactions(const YAML::Node & network,
       else
         function_rxn_list->push_back(rxn);
 
-      if (rxn->isElastic() && type != RATE_BASED)
-        throw InvalidReaction(rxn_list->back()->expression(),
-                              "Elastic reactions can only be in the '" + RATE_BASED + "' block");
-
       printGreen("Reaction Validated: " + rxn->expression());
       cout << endl;
 

--- a/src/NetworkParser.C
+++ b/src/NetworkParser.C
@@ -261,7 +261,7 @@ NetworkParser::writeReactionTable(const string & file, TableWriterBase & writer)
 
   if (_xsec_based.size() > 0)
   {
-    writer.beginRateBasedSection();
+    writer.beginXSecBasedSection();
     tableHelper(writer,
                 &TableWriterBase::beginFunctionalTable,
                 &TableWriterBase::endFunctionalTable,

--- a/test/gold/basic_rate_table.tex
+++ b/test/gold/basic_rate_table.tex
@@ -1,0 +1,37 @@
+\documentclass{article}
+\usepackage{tabu}
+\usepackage{float}
+\usepackage{graphicx}
+\usepackage{amsmath}
+\usepackage[top=1cm]{geometry}
+\tabulinesep = 1.5mm
+
+\usepackage[
+  backend=biber,
+  style=numeric,
+  sorting=nty,
+]{biblatex}
+
+\addbibresource{argon_works.bib}
+
+
+\begin{document}
+
+\newpage
+\section{Rate Reactions}
+\begin{table}[H]
+  \centering
+  \resizebox{\columnwidth}{!}{
+    \begin{tabu}{clcccccccc}
+      No. & Reaction & $A$ & $n_e$ & $E_e$ & $n_g$ & $E_g$ & $\Delta \varepsilon_e$ & $\Delta \varepsilon_g$ & Ref.\\
+      \hline
+      \hline
+      1 & Ar + e $\rightarrow$ Ar + e &  & & EEDF & & & 0.00 & 0.00 & \cite{lymberopoulos1993fluid} \\
+    \end{tabu}
+  }
+\end{table}
+
+\newpage
+\printbibliography
+
+\end{document}

--- a/test/gold/basic_xsec_table.tex
+++ b/test/gold/basic_xsec_table.tex
@@ -1,0 +1,37 @@
+\documentclass{article}
+\usepackage{tabu}
+\usepackage{float}
+\usepackage{graphicx}
+\usepackage{amsmath}
+\usepackage[top=1cm]{geometry}
+\tabulinesep = 1.5mm
+
+\usepackage[
+  backend=biber,
+  style=numeric,
+  sorting=nty,
+]{biblatex}
+
+\addbibresource{argon_works.bib}
+
+
+\begin{document}
+
+\newpage
+\section{Cross Section Reactions}
+\begin{table}[H]
+  \centering
+  \resizebox{\columnwidth}{!}{
+    \begin{tabu}{clcccccccc}
+      No. & Reaction & $A$ & $n_e$ & $E_e$ & $n_g$ & $E_g$ & $\Delta \varepsilon_e$ & $\Delta \varepsilon_g$ & Ref.\\
+      \hline
+      \hline
+      1 & Ar + e $\rightarrow$ Ar + e &  & & EEDF & & & 0.00 & 0.00 & \cite{lymberopoulos1993fluid} \\
+    \end{tabu}
+  }
+\end{table}
+
+\newpage
+\printbibliography
+
+\end{document}

--- a/test/inputs/elastic_xsec.yaml
+++ b/test/inputs/elastic_xsec.yaml
@@ -1,0 +1,8 @@
+data-path: inputs/data/
+bibliography: inputs/argon_works.bib
+
+xsec-based:
+  - reaction: Ar + e -> Ar + e
+    elastic: true
+    file: ar_elastic.txt
+    references: lymberopoulos1993fluid

--- a/test/inputs/simple_rate.yaml
+++ b/test/inputs/simple_rate.yaml
@@ -1,0 +1,8 @@
+data-path: inputs/data/
+bibliography: inputs/argon_works.bib
+
+rate-based:
+  - reaction: Ar + e -> Ar + e
+    elastic: true
+    file: ar_elastic.txt
+    references: lymberopoulos1993fluid

--- a/test/tests/DefaultTableWriterTest.C
+++ b/test/tests/DefaultTableWriterTest.C
@@ -40,3 +40,21 @@ TEST_F(DefaultTableWriterTest, MultipleReactionsSameNote)
   np.writeReactionTable("outputs/notes_test.tex");
   EXPECT_FILES_EQ("gold/notes_test.tex", "outputs/notes_test.tex");
 }
+
+TEST_F(DefaultTableWriterTest, SimpleCrossSectionTableTest)
+{
+  prism::NetworkParser np;
+
+  np.parseNetwork("inputs/elastic_xsec.yaml");
+  np.writeReactionTable("outputs/basic_xsec_table.tex");
+  EXPECT_FILES_EQ("gold/basic_xsec_table.tex", "outputs/basic_xsec_table.tex");
+}
+
+TEST_F(DefaultTableWriterTest, SimpleRateTableTest)
+{
+  prism::NetworkParser np;
+
+  np.parseNetwork("inputs/simple_rate.yaml");
+  np.writeReactionTable("outputs/basic_rate_table.tex");
+  EXPECT_FILES_EQ("gold/basic_rate_table.tex", "outputs/basic_rate_table.tex");
+}

--- a/test/tests/NetworkParserTest.C
+++ b/test/tests/NetworkParserTest.C
@@ -709,7 +709,7 @@ TEST_F(NetworkParserTest, ReactionPrintingMethods)
   EXPECT_FILES_EQ(file, gold_file);
 }
 
-TEST(NetworkParserest, ElasticXsecReaction)
+TEST_F(NetworkParserTest, ElasticXsecReaction)
 {
   prism::NetworkParser np;
   EXPECT_NO_THROW(np.parseNetwork("inputs/elastic_xsec.yaml"));

--- a/test/tests/NetworkParserTest.C
+++ b/test/tests/NetworkParserTest.C
@@ -708,3 +708,9 @@ TEST_F(NetworkParserTest, ReactionPrintingMethods)
   out4.close();
   EXPECT_FILES_EQ(file, gold_file);
 }
+
+TEST(NetworkParserest, ElasticXsecReaction)
+{
+  prism::NetworkParser np;
+  EXPECT_NO_THROW(np.parseNetwork("inputs/elastic_xsec.yaml"));
+}


### PR DESCRIPTION
Removes a check in the parser functionality that ensured that all elastic reactions needed to be rate based. This enables cross section based reactions to be elastic.

This also updates the documentation to more accurately reflect how the conda environment is meant to be utilized.

