### PR TITLE
Updating Makefile to address WSL build issues.

### DIFF
--- a/Makefile-as-dll
+++ b/Makefile-as-dll
@@ -40,7 +40,7 @@ endif
 # Build the shared library
 $(LIBRARY_NAME): $(OBJECTS)
 	@echo "Building $(LIBRARY_NAME)"
-	@$(CXX) $(CXXFLAGS) -B$(CONDA_PREFIX)/bin $(INCLUDE_PATH) $(LIBRARY_PATH) -I$(INCDIR) -shared -o $@ $(OBJECTS) $(LINKS) $(INSTALL_NAME_FLAG)
+	@$(CXX) $(CXXFLAGS) -B$(CONDA_PREFIX)/bin $(INCLUDE_PATH) $(LIBRARY_PATH) -I$(INCDIR) -shared -o $@ $(OBJECTS) $(LINKS) $(INSTALL_NAME_FLAG) -Wl,-rpath,$(CONDA_PREFIX)/lib
 	@echo "$(LIBRARY_NAME) built successfully!"
 
 # Build all of the source files for the library


### PR DESCRIPTION
- Some in the research group have experieneced an issue with linking libraries when buildind prism as a shared library
  - Seems to only be an issue when using WSL, was not able to reproduce on Linux or MacOS
- Testing on a WSL machine revealed that the issue was related to the -rpath in linking instructions when building prism as a dll the makefile has been updated to account for this

When examining the dll file that is produced when compilation is completed on WSL with ldd we see something like the following 

```
libyaml-cpp.0.8.dylib => No location found 
libfmt.12.dylib => No location found 
```

After adding the lines in this PR to the Makefile this issue was resolved.

If an executable or dynamically linkable library file reports that it is unable to find a dynamically linkable library again. Please inspect the linking information and confirm that it looks something like this.

```
libyaml-cpp.0.8.dylib => <absolute path to library>/libyaml-cpp.0.8.dylib
libfmt.12.dylib => <absolute path to library>/libfmt.12.dylib
```


@cody-d10  Helped resolve this issue as well.