### PR TITLE
Updating moose submodule for documentation build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  #  Check all submodule dependencies every week (Fridays at 6PM MT / Saturdays at 1AM UTC)
+  - package-ecosystem: "gitsubmodule"
+    schedule:
+        interval: "weekly"
+        day: "saturday"
+        time: "01:00"
+    directory: "/"
+    commit-message:
+      prefix: "[refs #0] "
+    allow:
+      - dependency-name: "moose"
+  # Maintain dependencies for GitHub Actions once a month
+  - package-ecosystem: "github-actions"
+    schedule:
+      interval: "monthly"
+    directory: "/"
+    commit-message:
+      prefix: "[refs #0] "


### PR DESCRIPTION
Currently documentation is not working due to the moose submodule and the moose conda environment being out of sync. This updates that for the documentation build. 